### PR TITLE
feat: Add dynamic API versioning

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -52,8 +52,8 @@ func run() error {
 	}
 	log.Printf("✅ Configuration loaded for %s environment", environment)
 
-	// 2. Create DI container
-	container, err := config.NewProductionContainerFromEnvironment(environment)
+	// 2. Create DI container with version information
+	container, err := config.NewProductionContainerFromEnvironmentWithVersion(environment, Version)
 	if err != nil {
 		return fmt.Errorf("failed to create DI container: %w", err)
 	}

--- a/internal/api/http/handlers/health_handler.go
+++ b/internal/api/http/handlers/health_handler.go
@@ -6,11 +6,15 @@ import (
 )
 
 // HealthHandler handles health check requests
-type HealthHandler struct{}
+type HealthHandler struct {
+	version string
+}
 
 // NewHealthHandler creates a new health handler
-func NewHealthHandler() *HealthHandler {
-	return &HealthHandler{}
+func NewHealthHandler(version string) *HealthHandler {
+	return &HealthHandler{
+		version: version,
+	}
 }
 
 // HealthResponse represents the health check response
@@ -31,7 +35,7 @@ func (h *HealthHandler) Health(w http.ResponseWriter, r *http.Request) {
 	response := HealthResponse{
 		Status:  "healthy",
 		Service: "billing-service",
-		Version: "1.0.0",
+		Version: h.version,
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -15,15 +15,22 @@ type Server struct {
 	clientHandler  *handlers.ClientHandler
 	healthHandler  *handlers.HealthHandler
 	errorHandler   *middleware.ErrorHandler
+	version        string
 }
 
 // NewServer creates a new HTTP server with dependencies
 func NewServer(billingService *application.BillingService) *Server {
+	return NewServerWithVersion(billingService, "dev")
+}
+
+// NewServerWithVersion creates a new HTTP server with dependencies and version
+func NewServerWithVersion(billingService *application.BillingService, version string) *Server {
 	return &Server{
 		billingService: billingService,
 		clientHandler:  handlers.NewClientHandler(billingService),
-		healthHandler:  handlers.NewHealthHandler(),
+		healthHandler:  handlers.NewHealthHandler(version),
 		errorHandler:   middleware.NewErrorHandler(),
+		version:        version,
 	}
 }
 

--- a/internal/config/di_integration.go
+++ b/internal/config/di_integration.go
@@ -132,6 +132,13 @@ func NewProductionContainer(config *Config) *di.Container {
 	return di.NewContainer(diConfig)
 }
 
+// NewProductionContainerWithVersion creates a DI container with version information
+func NewProductionContainerWithVersion(config *Config, version string) *di.Container {
+	diConfig := config.ToDIConfig()
+	diConfig.Version = version
+	return di.NewContainer(diConfig)
+}
+
 // NewProductionContainerFromEnvironment loads config and creates DI container
 func NewProductionContainerFromEnvironment(environment string) (*di.Container, error) {
 	config, err := LoadConfig(environment)
@@ -140,5 +147,16 @@ func NewProductionContainerFromEnvironment(environment string) (*di.Container, e
 	}
 
 	container := NewProductionContainer(config)
+	return container, nil
+}
+
+// NewProductionContainerFromEnvironmentWithVersion loads config and creates DI container with version
+func NewProductionContainerFromEnvironmentWithVersion(environment string, version string) (*di.Container, error) {
+	config, err := LoadConfig(environment)
+	if err != nil {
+		return nil, err
+	}
+
+	container := NewProductionContainerWithVersion(config, version)
 	return container, nil
 }

--- a/internal/di/config.go
+++ b/internal/di/config.go
@@ -47,6 +47,9 @@ type ContainerConfig struct {
 
 	// Environment
 	Environment string `yaml:"environment" json:"environment"`
+
+	// Version information
+	Version string `yaml:"version" json:"version"`
 }
 
 // UnitTestConfig returns a configuration suitable for unit testing (memory storage)

--- a/internal/di/container.go
+++ b/internal/di/container.go
@@ -123,7 +123,11 @@ func (c *Container) GetHTTPServer() (*httpserver.Server, error) {
 			c.setError("http_server", NewProviderError("http_server", err))
 			return
 		}
-		c.httpServer = HTTPServerProvider(billingService)
+		version := c.config.Version
+		if version == "" {
+			version = "dev"
+		}
+		c.httpServer = HTTPServerProvider(billingService, version)
 	})
 
 	if err := c.getError("http_server"); err != nil {

--- a/internal/di/providers.go
+++ b/internal/di/providers.go
@@ -159,8 +159,8 @@ func BillingServiceProvider(clientRepo repository.ClientRepository) *application
 }
 
 // HTTPServerProvider creates an HTTP server with the given services
-func HTTPServerProvider(billingService *application.BillingService) *httpserver.Server {
-	return httpserver.NewServer(billingService)
+func HTTPServerProvider(billingService *application.BillingService, version string) *httpserver.Server {
+	return httpserver.NewServerWithVersion(billingService, version)
 }
 
 // ProviderError represents an error in provider creation


### PR DESCRIPTION
## Summary
- Adds dynamic API versioning to health endpoint
- Version is now injected at build time instead of hardcoded

## Changes
- Updated health handler to accept version as parameter
- Modified HTTP server to support version injection  
- Extended DI container configuration with version field
- Updated main.go to pass build-time version to container
- Health endpoint now returns actual version instead of hardcoded 1.0.0

## Testing
The health endpoint now correctly returns the version:
- During development: returns 'dev'
- In containers: returns the actual version from semantic release
- In production: returns the release version number

This is a minor feature addition that enables proper versioning across our API endpoints.